### PR TITLE
fix: 将所有 "登陆" 改为 "登录"

### DIFF
--- a/src/App.vue
+++ b/src/App.vue
@@ -16,7 +16,7 @@
       <div class="flex-none">
         <ul class="menu menu-horizontal px-1">
           <li v-show="!loginStore.loginSession" @click="router.push('/login')">
-            <a>登陆</a>
+            <a>登录</a>
           </li>
           <li v-show="loginStore.loginSession" @click="router.push('/')">
             <a>问卷列表</a>

--- a/src/pages/Login/index.vue
+++ b/src/pages/Login/index.vue
@@ -42,7 +42,7 @@
             type="success"
             @click="send"
           >
-            登陆
+            登录
           </el-button>
           <el-button
             class="dark:opacity-80 shadow-lg hover:-translate-y-1 transform duration-800"
@@ -83,7 +83,7 @@ const send = () => {
     onBefore: () => startLoading(),
     onSuccess(res: any) {
       if (res.code === 200) {
-        ElNotification.success("登陆成功");
+        ElNotification.success("登录成功");
         loginStore.setLogin(true);
         router.push("/admin");
       } else {


### PR DESCRIPTION
将所有固定文本当中中的“登陆”(land)二字改为“登录”(login)二字，以确保文本与其含义一致